### PR TITLE
[VERT-3] center curses display on root element

### DIFF
--- a/test/test_curses.py
+++ b/test/test_curses.py
@@ -64,6 +64,11 @@ class TestCurses(unittest.TestCase):
         temp_display.display_vert_tree(root, 4)
         assert curses.getsyx()[1] == 0
 
+    def test_root_centering(self):
+        root = create_tree_4()
+        self.display.display_vert_tree(root, 4)
+        assert self.display.x != 0
+
     def test_random_trees(self):
         root = generate_random_tree(10)
         for _ in range(20):

--- a/test/util.py
+++ b/test/util.py
@@ -67,6 +67,15 @@ def create_tree_3(add_left=True):
     return root
 
 
+def create_tree_4():
+    root = create_tree_3()
+    root.left.left.left.left = TreeNode("i")
+    root.left.left.left.left.left = TreeNode("j")
+    root.left.left.left.left.left.left = TreeNode("k")
+    root.left.left.left.left.left.left.left = TreeNode("l")
+    return root
+
+
 @contextmanager
 def captured_output():
     new_out, new_err = StringIO(), StringIO()


### PR DESCRIPTION
This PR centers curses pad windows on the root element of the tree. Previously they were always started from the top-left which on large trees could mean they are far from center. 

Also removes the visible screen cursor. 