### PR TITLE
[VERT-4] rework exception handling

### DIFF
--- a/test/test_base.py
+++ b/test/test_base.py
@@ -3,6 +3,7 @@ import unittest
 from util import captured_output, create_tree_1
 from vert_tree import CursesDisplay, TerminalDisplay
 
+
 class TestBase(unittest.TestCase):
     def setUp(self):
         self.term_display = TerminalDisplay(False)
@@ -13,19 +14,19 @@ class TestBase(unittest.TestCase):
         with captured_output() as (stdout, stderr):
             self.term_display.display_vert_tree(root, 4)
             output = stdout.getvalue().splitlines()
-        assert output[0] == 'Error: no tree to display'
+        assert output[0] == "Error: no tree to display"
         with captured_output() as (stdout, stderr):
             self.curses_display.display_vert_tree(root, 4)
             output = stdout.getvalue().splitlines()
-        assert output[0] == 'Error: no tree to display'
+        assert output[0] == "Error: no tree to display"
 
     def test_non_power_2(self):
         root = create_tree_1()
         with captured_output() as (stdout, stderr):
             self.term_display.display_vert_tree(root, 3)
             output = stdout.getvalue().splitlines()
-        assert output[0] == 'Error: edge spacing must be a power of two'
+        assert output[0] == "Error: edge spacing must be a power of two"
         with captured_output() as (stdout, stderr):
             self.curses_display.display_vert_tree(root, 3)
             output = stdout.getvalue().splitlines()
-        assert output[0] == 'Error: edge spacing must be a power of two'
+        assert output[0] == "Error: edge spacing must be a power of two"

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,0 +1,31 @@
+import unittest
+
+from util import captured_output, create_tree_1
+from vert_tree import CursesDisplay, TerminalDisplay
+
+class TestBase(unittest.TestCase):
+    def setUp(self):
+        self.term_display = TerminalDisplay(False)
+        self.curses_display = CursesDisplay()
+
+    def test_none_root(self):
+        root = None
+        with captured_output() as (stdout, stderr):
+            self.term_display.display_vert_tree(root, 4)
+            output = stdout.getvalue().splitlines()
+        assert output[0] == 'Error: no tree to display'
+        with captured_output() as (stdout, stderr):
+            self.curses_display.display_vert_tree(root, 4)
+            output = stdout.getvalue().splitlines()
+        assert output[0] == 'Error: no tree to display'
+
+    def test_non_power_2(self):
+        root = create_tree_1()
+        with captured_output() as (stdout, stderr):
+            self.term_display.display_vert_tree(root, 3)
+            output = stdout.getvalue().splitlines()
+        assert output[0] == 'Error: edge spacing must be a power of two'
+        with captured_output() as (stdout, stderr):
+            self.curses_display.display_vert_tree(root, 3)
+            output = stdout.getvalue().splitlines()
+        assert output[0] == 'Error: edge spacing must be a power of two'

--- a/test/test_curses.py
+++ b/test/test_curses.py
@@ -68,13 +68,13 @@ class TestCurses(unittest.TestCase):
         root = create_tree_4()
         self.display.display_vert_tree(root, 4)
         assert self.display.x != 0
-    
+
     def test_too_large_tree(self):
         root = generate_random_tree(20)
         with captured_output() as (stdout, stderr):
             self.display.display_vert_tree(root)
             output = stdout.getvalue().splitlines()
-        assert output[0][:45] == 'The curses lib cannot handle a tree so large!'
+        assert output[0][:45] == "The curses lib cannot handle a tree so large!"
 
     def test_random_trees(self):
         root = generate_random_tree(10)

--- a/test/test_curses.py
+++ b/test/test_curses.py
@@ -68,6 +68,13 @@ class TestCurses(unittest.TestCase):
         root = create_tree_4()
         self.display.display_vert_tree(root, 4)
         assert self.display.x != 0
+    
+    def test_too_large_tree(self):
+        root = generate_random_tree(20)
+        with captured_output() as (stdout, stderr):
+            self.display.display_vert_tree(root)
+            output = stdout.getvalue().splitlines()
+        assert output[0][:45] == 'The curses lib cannot handle a tree so large!'
 
     def test_random_trees(self):
         root = generate_random_tree(10)

--- a/test/test_terminal.py
+++ b/test/test_terminal.py
@@ -58,3 +58,11 @@ class TestTerminal(unittest.TestCase):
         assert output[3][22] == "/"
         assert output[3][26] == "\\"
         assert output[5][3] == "/"
+
+    def test_too_large_tree(self):
+        temp_display = TerminalDisplay()
+        root = generate_random_tree(20)
+        with captured_output() as (stdout, stderr):
+            temp_display.display_vert_tree(root, 4)
+            output = stdout.getvalue().splitlines()
+        assert output[0][:20] == "Error: tree width is"

--- a/vert_tree/terminal_display.py
+++ b/vert_tree/terminal_display.py
@@ -8,6 +8,7 @@ from vert_tree.common import Edge
 
 class TerminalDisplay(BaseTreeDisplay):
     def __init__(self, test_terminal_width=True):
+        self.function = self._base_display_tree
         self.test_terminal_width = test_terminal_width
 
     def _init_display(self, tree):

--- a/vert_tree/terminal_display.py
+++ b/vert_tree/terminal_display.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import subprocess
 
-from vert_tree.base import BaseTreeDisplay
+from vert_tree.base import BaseTreeDisplay, TreeDisplayError
 from vert_tree.common import Edge
 
 
@@ -16,9 +16,9 @@ class TerminalDisplay(BaseTreeDisplay):
             # support python 2/3
             terminal_width = int(subprocess.check_output(["stty", "size"]).split()[0])
             if tree.total_width > terminal_width:
-                print("Error: tree width is {}, terminal width is {}".format(tree.total_width, terminal_width))
-                return False
-        return True
+                raise TreeDisplayError(
+                    "Error: tree width is {}, terminal width is {}".format(tree.total_width, terminal_width)
+                )
 
     def _print_vertices(self, level_verts, width):
         self._truncate_node_vals(level_verts)


### PR DESCRIPTION
Reworks exception handling across implementations to make things much more standard/clear by raising a custom exception. The general exception cases are:

1) no tree provided
2) tree wider than terminal width (TerminalDisplay) or too large for curses lib mem (CursesDIsplay)
3) a arrow_spacing value was provided that is not a power of 2. Non-powers of 2 can cause the arrows too look a bit weird in certain circumstances, maybe this should be allowed?